### PR TITLE
correção nas urls que utilizam a env server_name

### DIFF
--- a/sme_material_apps/custom_user/api/viewsets.py
+++ b/sme_material_apps/custom_user/api/viewsets.py
@@ -77,7 +77,7 @@ class UserViewSet(RetrieveModelMixin, ListModelMixin, UpdateModelMixin, GenericV
         token_generator = PasswordResetTokenGenerator()
         token = token_generator.make_token(usuario)
         env = environ.Env()
-        url = f'https://{env("SERVER_NAME")}/fornecedor/recuperar-senha?id={str(usuario.id)}&confirmationKey={token}'
+        url = f'{env("SERVER_NAME")}/fornecedor/recuperar-senha?id={str(usuario.id)}&confirmationKey={token}'
         enviar_email_recuperar_senha.delay(
             usuario.email,
             {

--- a/sme_material_apps/proponentes/models/proponente.py
+++ b/sme_material_apps/proponentes/models/proponente.py
@@ -169,7 +169,7 @@ class Proponente(ModeloBase, TemObservacao):
             log.info(f'Enviando confirmação de pré-cadastro (Protocolo:{self.protocolo}) enviada para {self.email}.')
 
             env = environ.Env()
-            url = f'https://{env("SERVER_NAME")}/fornecedor/cadastro?uuid={self.uuid}'
+            url = f'{env("SERVER_NAME")}/fornecedor/cadastro?uuid={self.uuid}'
             enviar_email_confirmacao_pre_cadastro.delay(self.email,
                                                         {'protocolo': self.protocolo, 'url_cadastro': url})
 


### PR DESCRIPTION
Este PR:
- corrige duplicação do https nas URLS que utilizavam a variavel de ambiente server_name