### PR TITLE
hotfix/81504-erro-ao-trocar-valores-loja-especifica

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -371,3 +371,4 @@ sentry_sdk.init(
 )
 
 GEOREF_API_URL = env('GEOREF_API_URL')
+DATA_UPLOAD_MAX_NUMBER_FIELDS = None


### PR DESCRIPTION
# Este PR:

- Adiciona parâmetro DATA_UPLOAD_MAX_NUMBER_FIELDS
Proponentes com muitas lojas ao realizar atualizações sofria com erro de DATA_UPLOAD_MAX_NUMBER_FIELDS por conta de valores padrões default

### Referência Azure:
- 81504